### PR TITLE
Revert "gemini: Increase in-call earpiece volume"

### DIFF
--- a/audio/mixer_paths_tasha.xml
+++ b/audio/mixer_paths_tasha.xml
@@ -51,7 +51,7 @@
     <ctl name="LINEOUT4 Volume" value="13" />
     <ctl name="HPHL Volume" value="20" />
     <ctl name="HPHR Volume" value="20" />
-    <ctl name="RX0 Digital Volume" value="89" />
+    <ctl name="RX0 Digital Volume" value="84" />
     <ctl name="RX1 Digital Volume" value="84" />
     <ctl name="RX2 Digital Volume" value="84" />
     <ctl name="RX3 Digital Volume" value="84" />


### PR DESCRIPTION
This reverts commit cd1a6148794a1d4d90ea03dcad3e807723553a15.
Hax no longer needed with Oreo blobs.

Change-Id: Idd09be8a88fd7665cf0410b27cc7df61be08ad36
Signed-off-by: Giuseppe Barillari <joe2k01dev@gmail.com>