### PR TITLE
gemini: State the current required firmware version

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,1 +1,1 @@
-require version-modem=2018-04-20 15:21:31
+require version-modem=2018-04-20 15:21:31,8.5.10


### PR DESCRIPTION
 * This will now be shown to the users if assert on
   modem time-stamp fails. Hopefully it will be more
   understandable.

Change-Id: Ic066984646e70cb3cd7b46cbbd28d500da9b30cc